### PR TITLE
Dev

### DIFF
--- a/backend/db/migrations/20241015200828-create-spot-image.js
+++ b/backend/db/migrations/20241015200828-create-spot-image.js
@@ -46,6 +46,6 @@ module.exports = {
   },
   async down(queryInterface, Sequelize) {
     options.tableName = "SpotImages";
-    return queryInterface.dropTable(options.tableName);
+    return queryInterface.dropTable(options.tableName,  { cascade: true });
   }
 };

--- a/backend/db/models/spot.js
+++ b/backend/db/models/spot.js
@@ -17,7 +17,10 @@ module.exports = (sequelize, DataTypes) => {
       ),
         Spot.hasMany(
           models.SpotImage,
-          {foreignKey: 'spotId'}
+          {
+            onDelete: 'cascade',
+            foreignKey: 'spotId'
+          }
         ),
         Spot.hasMany(
           models.Booking,

--- a/backend/notes.md
+++ b/backend/notes.md
@@ -2,6 +2,8 @@
 
 ## Questions
 
+- Delete a Spot route works correctly on local environment, but fails on live environment because it validates foreign key constraint on spotImages table
+
 - Why does Render.com no longer automatically re-deploy when we push to github? We changed the branch from main to dev, but it does not automatically re-deploy when we push to dev.
 
 - Are we able to change Raihan's repo url so that he is able to re-deploy from my repo (which we are sharing as our joint project repo)?

--- a/backend/notes.md
+++ b/backend/notes.md
@@ -35,6 +35,10 @@
 
 ## Goals
 
+### Route: Get All Reviews
+
+---
+
 ### Route: Delete a Spot
 
 #### Notes

--- a/backend/routes/api/index.js
+++ b/backend/routes/api/index.js
@@ -7,6 +7,7 @@ const sessionRouter = require('./session.js');
 const usersRouter = require('./users.js');
 const spotsRouter = require('./spots.js')
 const spotImagesRouter = require('./spotImages.js')
+const reviewsRouter = require('./reviews.js')
 const { restoreUser, requireAuth } = require("../../utils/auth.js");
 
 // Connect restoreUser middleware to the API router
@@ -28,6 +29,8 @@ router.use('/users', usersRouter);
 router.use('/spots', spotsRouter); //! Spots router
 
 router.use('/spotImages', spotImagesRouter);
+
+router.use('/reviews', reviewsRouter);
 
 // router.post('/test', (req, res) => { // route for testing POST requests
 //   res.json({ requestBody: req.body });

--- a/backend/routes/api/reviews.js
+++ b/backend/routes/api/reviews.js
@@ -4,4 +4,26 @@ const { Review, ReviewImage, Spot, User } = require('../../db/models');
 const { requireAuth } = require('../../utils/auth');
 const router = express.Router();
 
+//! Get All Reviews of Current User
+
+router.get('/current', requireAuth, async (req, res, next) => {
+
+    try {
+
+        let id = req.user.id;
+
+        let reviews = await Review.findAll({
+
+            where: {
+                userId: id
+            }
+        })
+
+        res.json({Reviews: reviews})
+
+    } catch(err) {
+        next(err);
+    };
+})
+
 module.exports = router;

--- a/backend/routes/api/reviews.js
+++ b/backend/routes/api/reviews.js
@@ -1,0 +1,7 @@
+const express = require('express');
+
+const { Review, ReviewImage, Spot, User } = require('../../db/models');
+const { requireAuth } = require('../../utils/auth');
+const router = express.Router();
+
+module.exports = router;

--- a/backend/routes/api/spots.js
+++ b/backend/routes/api/spots.js
@@ -291,7 +291,7 @@ router.post('/:spotId/images', requireAuth, async (req,res,next) => {
     }
 })
 
-//! Edit Spot 
+//! Edit Spot
 
 router.put('/:spotId',requireAuth,async(req,res,next)=>{
     try{
@@ -325,6 +325,9 @@ router.put('/:spotId',requireAuth,async(req,res,next)=>{
         next(err)
     }
 })
+
+//! Delete A Spot
+
 router.delete('/:spotId',requireAuth,async(req,res,next)=>{
     try{
         const spotId = req.params.spotId;

--- a/backend/routes/api/spots.js
+++ b/backend/routes/api/spots.js
@@ -325,6 +325,32 @@ router.put('/:spotId',requireAuth,async(req,res,next)=>{
         next(err)
     }
 })
+router.delete('/:spotId',requireAuth,async(req,res,next)=>{
+    try{
+        const spotId = req.params.spotId;
+        const userId = req.user.id;
 
+        const spot = await Spot.findByPk(spotId);
+        if(!spot){
+            return res.status(404).json({
+                message:"Spot couldn't be found"
+            })
+        }
+        if(spot.ownerId !== userId){
+            return res.status(403).json({
+                message:"Unauthorized"
+            })
+        }
+       await spot.destroy();
+       res.status(200).json({
+        message:"Successfully deleted"
+       })
+
+    }
+    catch(err){
+        next(err)
+    }
+
+})
 
 module.exports = router;

--- a/backend/routes/api/spots.js
+++ b/backend/routes/api/spots.js
@@ -291,6 +291,8 @@ router.post('/:spotId/images', requireAuth, async (req,res,next) => {
     }
 })
 
+//! Edit Spot 
+
 router.put('/:spotId',requireAuth,async(req,res,next)=>{
     try{
         const spotId = req.params.spotId;


### PR DESCRIPTION
Add labels to spots

Implemented delete-spot route. Tested in local environment successfully, failed tests in live environment because deleting a spot violates spotImages foreign key constraint. Tried to add onDelete: cascade to spot model file within association to spotImages but this strategy did not resolve the issue. We will talk to Phillip tonight in order to determine the correct solution. For now we are moving on to the Reviews routes.

We successfully created Reviews router.

Implemented Get-All-Reviews-of-Current-User route. Tested in local and live environment, both tests successful. 